### PR TITLE
should fix travis build

### DIFF
--- a/core/src/test/scala/ProtocolSpec.scala
+++ b/core/src/test/scala/ProtocolSpec.scala
@@ -27,7 +27,7 @@ import transport.netty._
 class ProtocolSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   val addr = new java.net.InetSocketAddress("localhost", 9002)
   val server = new TestServer
-  val shutdown: () => Unit = server.environment.serveNetty(addr, Executors.newCachedThreadPool, Monitoring.consoleLogger("ProtocolSpec-server"))
+  val shutdown: () => Unit = server.environment.serveNetty(addr, Executors.newCachedThreadPool)
 
   val endpoint = Endpoint.single(NettyTransport.single(addr, Set.empty, Monitoring.consoleLogger("ProtocolSpec")))
 

--- a/project.sbt
+++ b/project.sbt
@@ -19,3 +19,5 @@ lazy val `benchmark-protocol` = project.in(file("benchmark/protocol")).dependsOn
 lazy val `benchmark-server` = project.in(file("benchmark/server")).dependsOn(`benchmark-protocol`)
 
 lazy val `benchmark-client` = project.in(file("benchmark/client")).dependsOn(`benchmark-protocol`, `benchmark-server`)
+
+parallelExecution in Test := false

--- a/project.sbt
+++ b/project.sbt
@@ -20,4 +20,4 @@ lazy val `benchmark-server` = project.in(file("benchmark/server")).dependsOn(`be
 
 lazy val `benchmark-client` = project.in(file("benchmark/client")).dependsOn(`benchmark-protocol`, `benchmark-server`)
 
-parallelExecution in Test := false
+parallelExecution in Global := false


### PR DESCRIPTION
turn off parallelExecution in tests because scala.reflect isn't threadsa.fe (yay)

turn off monitoring ont he ProtocolSpec which is dumping a lot of 9s to the console