### PR TITLE
Support for scala 2.11.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+.idea/*
 
 .ivy2
 catapult/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
   - 2.10.4
+  - 2.11.5
 jdk:
   - oraclejdk7
   - openjdk6

--- a/benchmark/protocol/build.sbt
+++ b/benchmark/protocol/build.sbt
@@ -1,1 +1,1 @@
-libraryDependencies += "oncue.svc.remotely" %% "core" % "1.0-SNAPSHOT"
+libraryDependencies += "oncue.svc.remotely" %% "core" % "1.1-SNAPSHOT"

--- a/benchmark/server/build.sbt
+++ b/benchmark/server/build.sbt
@@ -1,5 +1,7 @@
+import common._
+
 scalacOptions += "-language:reflectiveCalls"
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+macrosSettings
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0" % "test"
+testSettings

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,3 +1,4 @@
+import common._
 
 name := "core"
 
@@ -23,13 +24,6 @@ libraryDependencies ++= Seq(
   "io.netty"           % "netty-codec"    % "4.0.25.Final"
 )
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+macrosSettings
 
-libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" %_)
-
-libraryDependencies += ("org.scalamacros" %% "quasiquotes" % "2.0.1")
-
-libraryDependencies ++= Seq(
-  "org.scalatest"  %% "scalatest"  % "2.2.1"  % "test",
-  "org.scalacheck" %% "scalacheck" % "1.11.6" % "test"
-)
+testSettings

--- a/core/src/main/scala/GenClient.scala
+++ b/core/src/main/scala/GenClient.scala
@@ -32,12 +32,13 @@ class GenClient(sigs: Signatures) extends StaticAnnotation {
 object GenClient {
   /**
     * this just allows us to put a $signature into a quasi-quote.
-    * implimented this way instead of by providing Liftable[Signature]
+    * implemented this way instead of by providing Liftable[Signature]
     * only because I gave up on trying to figure out the complex cake
     * of path-dependant types which is the current reflection api.
     */
-  def liftSignature(c: Context)(s: Signature): c.universe.Tree = {
+  def liftSignature(c: Context)(signature: Signature): c.universe.Tree = {
     import c.universe._
+    val s = signature
     val t: Tree = q"_root_.remotely.Signature(${s.name}, ${s.tag}, ${s.inTypes}, ${s.outType})"
     t
   }
@@ -50,7 +51,7 @@ object GenClient {
     // and evaluate it at compile-time.
     val s: Signatures = c.prefix.tree match {
       case q"new $name($sig)" =>
-        c.eval(c.Expr[Signatures](c.resetAllAttrs(q"{import remotely.codecs._; $sig}")))
+        c.eval(c.Expr[Signatures](c.resetLocalAttrs(q"{import remotely.codecs._; $sig}")))
       case _ => c.abort(c.enclosingPosition, "GenClient must be used as an annotation.")
     }
 

--- a/core/src/main/scala/GenServer.scala
+++ b/core/src/main/scala/GenServer.scala
@@ -54,7 +54,7 @@ object GenServer {
     // and evaluate it at compile-time.
     val p:Protocol = c.prefix.tree match {
       case q"new $name($protocol)" =>
-        c.eval(c.Expr[Protocol](c.resetAllAttrs(q"{import remotely.codecs._; $protocol}")))
+        c.eval(c.Expr[Protocol](c.resetLocalAttrs(q"{import remotely.codecs._; $protocol}")))
       case _ => c.abort(c.enclosingPosition, "GenServer must be used as an annotation.")
     }
 

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -1,3 +1,4 @@
+import common._
 
 scalacOptions ++= Seq(
   "-language:existentials",
@@ -6,8 +7,4 @@ scalacOptions ++= Seq(
 
 name := "examples"
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
-
-libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" %_)
-
-libraryDependencies += ("org.scalamacros" %% "quasiquotes" % "2.0.1")
+macrosSettings

--- a/project.sbt
+++ b/project.sbt
@@ -2,6 +2,8 @@ organization in Global := "oncue.svc.remotely"
 
 scalaVersion in Global := "2.10.4"
 
+crossScalaVersions in Global := Seq("2.10.4", "2.11.5")
+
 resolvers += Resolver.sonatypeRepo("releases")
 
 lazy val remotely = project.in(file(".")).aggregate(core, examples, `benchmark-server`, `benchmark-client`, test)

--- a/project/common.scala
+++ b/project/common.scala
@@ -1,0 +1,30 @@
+import sbt._
+import Keys._
+
+object common {
+
+  def macrosSettings = Seq(
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full),
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value
+    ) ++ (
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, scalaMajor)) if scalaMajor == 10 => Seq("org.scalamacros" %% "quasiquotes" % "2.1.0-M5")
+        case _ => Nil
+      }
+    )
+  )
+
+  val scalaTestVersion  = SettingKey[String]("scalatest version")
+  val scalaCheckVersion = SettingKey[String]("scalacheck version")
+
+  def testSettings = Seq(
+    scalaTestVersion     := "2.2.1",
+    scalaCheckVersion    := "1.11.6",
+    libraryDependencies ++= Seq(
+      "org.scalatest"  %% "scalatest"  % scalaTestVersion.value  % "test",
+      "org.scalacheck" %% "scalacheck" % scalaCheckVersion.value % "test"
+    )
+  )
+
+}

--- a/test-server/build.sbt
+++ b/test-server/build.sbt
@@ -1,7 +1,5 @@
+import common._
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+macrosSettings
 
-libraryDependencies ++= Seq(
-  "org.scalatest"  %% "scalatest"  % "2.2.1"  % "test",
-  "org.scalacheck" %% "scalacheck" % "1.11.6" % "test"
-)
+testSettings


### PR DESCRIPTION
 - add `common.scala` that includes common settings
   for tests and macros.

 - adjust build definitions in order to support scala 2.11
   and use settings from `common`.

 - change `GenClient` and `GenServer` to accommodate scala 2.11,
   there are still some deprecation warnings due to 2.10.4
   builds.

 - change CI definition to include scala 2.11
 - add IDEA to .gitignore.

Closes #26