### PR TITLE
macros: add macros compatibility shims

### DIFF
--- a/core/src/main/macros/scala-2.10/remotely/MacrosCompatibility.scala
+++ b/core/src/main/macros/scala-2.10/remotely/MacrosCompatibility.scala
@@ -1,0 +1,46 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2015 Verizon.  All Rights Reserved.
+//:
+//:   Licensed under the Apache License, Version 2.0 (the "License");
+//:   you may not use this file except in compliance with the License.
+//:   You may obtain a copy of the License at
+//:
+//:       http://www.apache.org/licenses/LICENSE-2.0
+//:
+//:   Unless required by applicable law or agreed to in writing, software
+//:   distributed under the License is distributed on an "AS IS" BASIS,
+//:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//:   See the License for the specific language governing permissions and
+//:   limitations under the License.
+//:
+//: ----------------------------------------------------------------------------
+
+package remotely
+
+trait MacrosCompatibility {
+  type Context = scala.reflect.macros.Context
+
+  def getDeclarations(c: Context)(tpe: c.universe.Type): c.universe.MemberScope =
+    tpe.declarations
+
+  def getParameterLists(c: Context)(method: c.universe.MethodSymbol): List[List[c.universe.Symbol]] =
+    method.paramss
+
+  def getDeclaration(c: Context)(tpe: c.universe.Type, name: c.universe.Name): c.universe.Symbol =
+    tpe.declaration(name)
+
+  def createTermName(c: Context)(name: String): c.universe.TermName =
+    c.universe.newTermName(name)
+
+  def createTypeName(c: Context)(name: String): c.universe.TypeName =
+    c.universe.newTypeName(name)
+
+  def resetLocalAttrs(c: Context)(tree: c.Tree): c.Tree =
+    c.resetLocalAttrs(tree)
+
+  def getTermNames(c: Context): c.universe.TermNamesApi =
+    c.universe.`nme`
+
+  def companionTpe(c: Context)(tpe: c.universe.Type): c.universe.Symbol =
+    tpe.typeSymbol.companionSymbol
+}

--- a/core/src/main/macros/scala-2.11/remotely/MacrosCompatibility.scala
+++ b/core/src/main/macros/scala-2.11/remotely/MacrosCompatibility.scala
@@ -1,0 +1,46 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2015 Verizon.  All Rights Reserved.
+//:
+//:   Licensed under the Apache License, Version 2.0 (the "License");
+//:   you may not use this file except in compliance with the License.
+//:   You may obtain a copy of the License at
+//:
+//:       http://www.apache.org/licenses/LICENSE-2.0
+//:
+//:   Unless required by applicable law or agreed to in writing, software
+//:   distributed under the License is distributed on an "AS IS" BASIS,
+//:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//:   See the License for the specific language governing permissions and
+//:   limitations under the License.
+//:
+//: ----------------------------------------------------------------------------
+
+package remotely
+
+trait MacrosCompatibility {
+  type Context = scala.reflect.macros.blackbox.Context
+
+  def getDeclarations(c: Context)(tpe: c.universe.Type): c.universe.MemberScope =
+    tpe.decls
+
+  def getParameterLists(c: Context)(method: c.universe.MethodSymbol): List[List[c.universe.Symbol]] =
+    method.paramLists
+
+  def getDeclaration(c: Context)(tpe: c.universe.Type, name: c.universe.Name): c.universe.Symbol =
+    tpe.decl(name)
+
+  def createTermName(c: Context)(name: String): c.universe.TermName =
+    c.universe.TermName(name)
+
+  def createTypeName(c: Context)(name: String): c.universe.TypeName =
+    c.universe.TypeName(name)
+
+  def resetLocalAttrs(c: Context)(tree: c.Tree): c.Tree =
+    c.untypecheck(tree)
+
+  def getTermNames(c: Context): c.universe.TermNamesApi =
+    c.universe.termNames
+
+  def companionTpe(c: Context)(tpe: c.universe.Type): c.universe.Symbol =
+    tpe.typeSymbol.companion
+}

--- a/core/src/main/scala/GenClient.scala
+++ b/core/src/main/scala/GenClient.scala
@@ -17,7 +17,6 @@
 
 package remotely
 
-import scala.reflect.macros.Context
 import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 
@@ -26,10 +25,10 @@ import scala.annotation.StaticAnnotation
  * `@GenClient(remotely.Protocol.empty) object MyClient`
  */
 class GenClient(sigs: Signatures) extends StaticAnnotation {
-  def macroTransform(annottees: Any*) = macro GenClient.impl
+  def macroTransform(annottees: Any*): Any = macro GenClient.impl
 }
 
-object GenClient {
+object GenClient extends MacrosCompatibility {
   /**
     * this just allows us to put a $signature into a quasi-quote.
     * implemented this way instead of by providing Liftable[Signature]
@@ -51,7 +50,7 @@ object GenClient {
     // and evaluate it at compile-time.
     val s: Signatures = c.prefix.tree match {
       case q"new $name($sig)" =>
-        c.eval(c.Expr[Signatures](c.resetLocalAttrs(q"{import remotely.codecs._; $sig}")))
+        c.eval(c.Expr[Signatures](resetLocalAttrs(c)(q"{import remotely.codecs._; $sig}")))
       case _ => c.abort(c.enclosingPosition, "GenClient must be used as an annotation.")
     }
 

--- a/project/common.scala
+++ b/project/common.scala
@@ -5,6 +5,7 @@ object common {
 
   def macrosSettings = Seq(
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full),
+  
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     ) ++ (
@@ -12,7 +13,10 @@ object common {
         case Some((2, scalaMajor)) if scalaMajor == 10 => Seq("org.scalamacros" %% "quasiquotes" % "2.1.0-M5")
         case _ => Nil
       }
-    )
+    ),
+  
+    unmanagedSourceDirectories in Compile +=
+      (sourceDirectory in Compile).value / "macros" / s"scala-${scalaBinaryVersion.value}"
   )
 
   val scalaTestVersion  = SettingKey[String]("scalatest version")


### PR DESCRIPTION
 - add macros compatibility shims such that scala 2.10.x
   and scala 2.11.x code uses what is most appropriate.