### PR TITLE
have CircuitBreaker.apply not return a task

### DIFF
--- a/core/src/main/scala/CircuitBreaker.scala
+++ b/core/src/main/scala/CircuitBreaker.scala
@@ -39,6 +39,7 @@ class CircuitBreaker(timeout: Duration,
         _ <- addFailure
         r <- Task.fail(e) : Task[A]
       } yield r
+
       case \/-(a) => for {
         _ <- close
         r <- Task.now(a)
@@ -80,6 +81,6 @@ class CircuitBreaker(timeout: Duration,
 }
 
 object CircuitBreaker {
-  def apply(timeout: Duration, maxErrors: Int): Task[CircuitBreaker] =
-    IORef(BreakerState()).map(new CircuitBreaker(timeout, maxErrors, _))
+  def apply(timeout: Duration, maxErrors: Int): CircuitBreaker =
+    new CircuitBreaker(timeout, maxErrors, IORef(BreakerState()))
 }

--- a/core/src/main/scala/IORef.scala
+++ b/core/src/main/scala/IORef.scala
@@ -32,7 +32,7 @@ sealed abstract class IORef[A] {
 }
 
 object IORef {
-  def apply[A](value: => A): Task[IORef[A]] = Task(new IORef[A] {
+  def apply[A](value: => A): IORef[A] = new IORef[A] {
     val ref = new AtomicReference(value)
     def read = Task(ref.get)
     def write(value: A) = Task(ref.set(value))
@@ -44,7 +44,7 @@ object IORef {
       p <- compareAndSet(a, a2)
       r <- if (p) Task(b) else atomicModify(f)
     } yield r
-  })
+  }
 }
 
 

--- a/core/src/test/scala/CircuitBreakerSpec.scala
+++ b/core/src/test/scala/CircuitBreakerSpec.scala
@@ -41,8 +41,7 @@ object CircuitBreakerSpec extends Properties("CircuitBreaker") {
     val x = b.toInt
     val n = x.abs
     val p = for {
-      cb <- CircuitBreaker(3.seconds, n)
-      r <- failures(n + 1, cb)
+      r <- failures(n + 1, CircuitBreaker(3.seconds, n))
     } yield r
     p.run match {
       case -\/(e) => e.getMessage == "oops"
@@ -58,8 +57,7 @@ object CircuitBreakerSpec extends Properties("CircuitBreaker") {
     val x = b.toInt
     val n = x.abs
     val p = for {
-      cb <- CircuitBreaker(3.seconds, n)
-      r <- failures(n + 2, cb)
+      r <- failures(n + 2, CircuitBreaker(3.seconds, n))
     } yield r
     p.run match {
       case -\/(CircuitBreakerOpen) => true
@@ -69,8 +67,8 @@ object CircuitBreakerSpec extends Properties("CircuitBreaker") {
 
   // The CB closes again
   property("closes") = secure {
+    val cb = CircuitBreaker(1.milliseconds, 0)
     val p = for {
-      cb <- CircuitBreaker(1.milliseconds, 0)
       _ <- cb(Task.fail(new Error("oops"))).attempt
       _ <- Task(Thread.sleep(2))
       // The breaker should have closed by now
@@ -81,8 +79,8 @@ object CircuitBreakerSpec extends Properties("CircuitBreaker") {
 
   // The CB doesn't open as long as there are successes
   property("stays-closed") = secure {
+    val cb = CircuitBreaker(3.hours, 1)
     val p = for {
-      cb <- CircuitBreaker(3.hours, 1)
       _ <- cb(Task.fail(new Error("oops"))).attempt
       _ <- cb(Task.now(0))
       _ <- cb(Task.fail(new Error("oops"))).attempt

--- a/core/src/test/scala/UberSpec.scala
+++ b/core/src/test/scala/UberSpec.scala
@@ -79,7 +79,7 @@ class UberSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     import Remote.implicits._
     import codecs._
     val call = evaluate(endpointUber, Monitoring.empty)(CountClient.ping(1))
-    
+
     val i: Int = call.apply(Context.empty).run
     val j: Int = call.apply(Context.empty).run
     j should be (2)


### PR DESCRIPTION
Not very useful, since flatMapping against the result creates a new circuit breaker for each computation