### PR TITLE
Make example code consistent

### DIFF
--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -225,7 +225,7 @@ object Main {
 
     val endpoint = Endpoint.single(transport).run
 
-    val f: Remote[Int] = FactorialClient.reduce(2 :: 4 :: 8 :: Nil)
+    val f: Remote[Int] = FactorialClient.factorial(8)
 
 	val task: Task[Int] = f.runWithoutContext(endpoint)
 


### PR DESCRIPTION
We are implementing a factorial remote function the whole time but suddenly it changes to a reduce call in the client example code.