### PR TITLE
build: upgrade sbt to 0.13.8

### DIFF
--- a/benchmark/client/build.sbt
+++ b/benchmark/client/build.sbt
@@ -9,3 +9,5 @@ mergeSettings
 scalacOptions ++= Seq("-language:postfixOps", "-language:reflectiveCalls")
 
 publish := {}
+
+libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8


### PR DESCRIPTION
 - add `scala-reflect` to client benchmark
   project as it fails to compile in 2.11
   as `core` only has "provided" scope on
   `scala-reflect`.