### PR TITLE
build: upgrade sbt

### DIFF
--- a/benchmark/client/build.sbt
+++ b/benchmark/client/build.sbt
@@ -6,6 +6,8 @@ assemblySettings
 
 mergeSettings
 
+macrosSettings
+
 scalacOptions ++= Seq("-language:postfixOps", "-language:reflectiveCalls")
 
 publish := {}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8


### PR DESCRIPTION
 - upgrade sbt to 0.13.8

 - add `macroSettings` to client benchmark
   project as it fails to compile in 2.11
   without `scala-reflect`.