### PR TITLE
build: upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ scala:
   - 2.10.5
   - 2.11.6
 jdk:
-  - oraclejdk7
-  - openjdk6
+  - oraclejdk8
+  - openjdk7
 
 script: sbt ++$TRAVIS_SCALA_VERSION +test
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -19,8 +19,8 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scodec"         %% "scodec-core"   % "1.7.0",
-  "org.scodec"         %% "scodec-scalaz" % "1.0.0",
+  "org.scodec"         %% "scodec-core"   % "1.8.1",
+  "org.scodec"         %% "scodec-scalaz" % "1.1.0",
   "org.scalaz"         %% "scalaz-core"   % "7.1.0",
   "org.scalaz.stream"  %% "scalaz-stream" % "0.7a",
   "org.apache.commons" % "commons-pool2"  % "2.2",

--- a/test-server/src/test/scala/DescribeSpec.scala
+++ b/test-server/src/test/scala/DescribeSpec.scala
@@ -61,7 +61,7 @@ class DescribeSpec extends FlatSpec
     desc should contain (Signature("foo", Nil, "remotely.test.Foo"))
     desc should contain (Signature("fooId", List(Field("in", "remotely.test.Foo")), "remotely.test.Foo"))
     desc should contain (Signature("foobar", List(Field("in", "remotely.test.Foo")), "remotely.test.Bar"))
-    desc should contain (Signature("describe", Nil, "List[Remotely.Signature]"))
+    desc should contain (Signature("describe", Nil, "List[remotely.Signature]"))
   }
 
   behavior of "Client"


### PR DESCRIPTION
 - upgrade scodec to 1.8.1 and thereby shapeless to 2.2.4.

 - upgrade scodec-scalaz to 1.1.0 in order to match
   scodec upgrade.

 - fix `DescribeSpec` wrt. casing error.

 - bump travis jdk version.