### PR TITLE
core: GenClient & GenServer are broken due to restricted accessibility of Field constructor

### DIFF
--- a/core/src/main/scala/Signatures.scala
+++ b/core/src/main/scala/Signatures.scala
@@ -21,7 +21,10 @@ import scala.reflect.runtime.universe.TypeTag
 import codecs._
 import scodec.Codec
 
-case class Field[+A]private[remotely](name: String, typeString: String)
+// TODO: ctor should really be private[remotely], but due
+// to macro code generation issue in `liftField` (`Gen.scala`)
+// we open it for the time being. See Github issue #89.
+case class Field[+A](name: String, typeString: String)
 object Field {
   def strict[A:TypeTag](name: String) = Field[A](name, Remote.toTag[A])
 }


### PR DESCRIPTION
 - change constructor accessibility of `Field` to be
   public rather than `private[remotely]` due to macro
   code generation issues.

   Reason that `private[remotely]` works fine for
   `remotely` tests and example projects is because
   all share the same package.

   Note:
    I do not have any better solution than loosen
    the accessibility restriction as of now, but
    I wish to put focus on the matter such that
    we can get a quick bugfix in 1.4.1.

    An example project that illustrates the issue
    can be found at:

    https://github.com/ahjohannessen/remotely-14

    and further discussion around the issue can be
    found here: http://bit.ly/1McVPL2 and here:
    https://gitter.im/scalamacros/paradise?at=55c37b2d7a6037e67c59d24d