### PR TITLE
 Signatures 'wrapResponse' returns invalid type parameter string #90

### DIFF
--- a/core/src/main/scala/Signatures.scala
+++ b/core/src/main/scala/Signatures.scala
@@ -41,7 +41,10 @@ case class Signature(name: String, params: List[Field[Any]], outType: String) {
 
   private def lhs = params.map(_.typeString).mkString(",")
 
-  private def lhsWithArrow = if (params.isEmpty) "" else s"$lhs => "
+  private def lhsWithArrow =
+    if (params.isEmpty) ""
+    else if (params.size == 1) s"$lhs => "
+    else s"($lhs) => "
 
   def typeString = lhsWithArrow + outType
 

--- a/core/src/test/scala/SignatureSpec.scala
+++ b/core/src/test/scala/SignatureSpec.scala
@@ -30,6 +30,6 @@ class SignatureSpec extends FlatSpec
   it should "be able to wrap a response type" in {
     Signature("foo",List(), "Baz").wrapResponse should be ("Response[Baz]")
     Signature("foo", List(Field("baz", "Baz")), "Qux").wrapResponse should be ("Baz => Response[Qux]")
-    Signature("foo", List(Field("baz", "Baz"), Field("qux", "Qux")), "Zod").wrapResponse should be ("Baz,Qux => Response[Zod]")
+    Signature("foo", List(Field("baz", "Baz"), Field("qux", "Qux")), "Zod").wrapResponse should be ("(Baz,Qux) => Response[Zod]")
   }
 }


### PR DESCRIPTION
Just wraps more than one argument in parentheses, so type parameter will be:
`[(A,B) => C]` instead of  `[A,B => C]`.
