### PR TITLE
bug fix + ci / sbt / scala upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: scala
 scala:
-  - 2.10.5
-  - 2.11.6
+  - 2.10.6
+  - 2.11.7
 jdk:
   - oraclejdk8
   - openjdk7
-
-script: sbt ++$TRAVIS_SCALA_VERSION +test
-
+script:
+  - sbt -J-Xss6M -J-Xmx4G ++$TRAVIS_SCALA_VERSION compile test:compile
+  - sbt -J-Xss6M -J-Xmx4G ++$TRAVIS_SCALA_VERSION test
 notifications:
   irc:
     channels:

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -17,10 +17,10 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scodec"         %% "scodec-core"   % "1.8.1",
+  "org.scodec"         %% "scodec-core"   % "1.8.2",
   "org.scodec"         %% "scodec-scalaz" % "1.1.0",
-  "org.scalaz"         %% "scalaz-core"   % "7.1.0",
-  "org.scalaz.stream"  %% "scalaz-stream" % "0.7a",
+  "org.scalaz"         %% "scalaz-core"   % "7.1.3",
+  "org.scalaz.stream"  %% "scalaz-stream" % "0.7.3a",
   "org.apache.commons" % "commons-pool2"  % "2.2",
   "io.netty"           % "netty-handler"  % "4.0.25.Final",
   "io.netty"           % "netty-codec"    % "4.0.25.Final"

--- a/project.sbt
+++ b/project.sbt
@@ -1,9 +1,9 @@
 
 organization in Global := "oncue.remotely"
 
-scalaVersion in Global := "2.10.5"
+scalaVersion in Global := "2.10.6"
 
-crossScalaVersions in Global := Seq("2.10.5", "2.11.6")
+crossScalaVersions in Global := Seq("2.10.6", "2.11.7")
 
 resolvers += Resolver.sonatypeRepo("releases")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9


### PR DESCRIPTION
 - adjust `.travis.yml` to separate compilation from
   test in order to have more memory when running
   tests.

 - change `NettyConnectionPool` to remove `ClientNegotiateCapabilities`
   when validation of capabilities fails in order to avoid having it
   try parsing an empty string just before failing with `IncompatibleServer`.

   Moreover, instruct sbt to use more memory
   for heap and stack.

 - bump dependencies `scodec-core` to `1.8.2`,
   `scalaz-stream` to `0.7.3a` and `scalaz-core`
   to `7.1.3`.

 - bump version of scala to `2.11.7` and `2.10.6`,
   and sbt to `0.13.9`.