### PR TITLE
core: upgrade netty + fix warning

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -22,8 +22,8 @@ libraryDependencies ++= Seq(
   "org.scalaz"         %% "scalaz-core"   % "7.1.3",
   "org.scalaz.stream"  %% "scalaz-stream" % "0.7.3a",
   "org.apache.commons" % "commons-pool2"  % "2.2",
-  "io.netty"           % "netty-handler"  % "4.0.25.Final",
-  "io.netty"           % "netty-codec"    % "4.0.25.Final"
+  "io.netty"           % "netty-handler"  % "4.0.32.Final",
+  "io.netty"           % "netty-codec"    % "4.0.32.Final"
 )
 
 common.macrosSettings

--- a/core/src/test/scala/SSLSpec.scala
+++ b/core/src/test/scala/SSLSpec.scala
@@ -210,7 +210,7 @@ class SSLSpec extends FlatSpec
 
       val fact = evaluate(endpoint, Monitoring.consoleLogger())(Client.factorial(10)).apply(Context.empty)
 
-      an[Exception] should be thrownBy fact.run
+      an[Exception] should be thrownBy fact.map(_ ⇒ ()).run
     } finally {
       shutdown.run
       transport.shutdown.run


### PR DESCRIPTION
 - update netty to `4.0.32.Final` as it comes with
   some improvements and bugfixes, see more [here](
   http://netty.io/news/2015/09/30/4-0-32-Final.html).

 - change `SslParameters` to use `SslContextBuilder`
   instead of deprecated `SslContext.newClientContext`
   and `SslContext.newServerContext`.

 - fix warning in `SSLSpec`.