### PR TITLE
make read, write and compareAndSet operations (at least possibly) run…

### DIFF
--- a/core/src/main/scala/IORef.scala
+++ b/core/src/main/scala/IORef.scala
@@ -34,10 +34,10 @@ sealed abstract class IORef[A] {
 object IORef {
   def apply[A](value: => A): IORef[A] = new IORef[A] {
     val ref = new AtomicReference(value)
-    def read = Task(ref.get)
-    def write(value: A) = Task(ref.set(value))
+    def read = Task.delay(ref.get)
+    def write(value: A) = Task.delay(ref.set(value))
     def compareAndSet(oldVal: A, newVal: A) =
-      Task(ref.compareAndSet(oldVal, newVal))
+      Task.delay(ref.compareAndSet(oldVal, newVal))
     def atomicModify[B](f: A => (A, B)) = for {
       a <- read
       (a2, b) = f(a)

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -17,6 +17,8 @@
 
 
 package object remotely {
+  import java.util.concurrent.{ Executors, ExecutorService, ThreadFactory }
+  import java.util.concurrent.atomic.AtomicInteger
   import scala.concurrent.duration._
   import scala.reflect.runtime.universe.TypeTag
   import scalaz.stream.Process
@@ -93,4 +95,16 @@ package object remotely {
   implicit val ByteVectorMonoid = Monoid.instance[ByteVector]((a,b) => a ++ b, ByteVector.empty)
 
   private[remotely] def fullyRead(s: Process[Task,BitVector]): Task[BitVector] = s.runFoldMap(x => x)
+
+  private[remotely] def fixedNamedThreadPool(name: String): ExecutorService =
+    Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors, namedThreadFactory("endpointHandlerPool"))
+
+  private[remotely] def namedThreadFactory(name: String): ThreadFactory = new ThreadFactory {
+    val num = new AtomicInteger(1)
+    def newThread(runnable: Runnable) = {
+      val t = new Thread(runnable, s"$name - ${num.getAndIncrement}")
+      t.setDaemon(true)
+      t
+    }
+  }
 }

--- a/core/src/main/scala/transport/netty/package.scala
+++ b/core/src/main/scala/transport/netty/package.scala
@@ -17,12 +17,4 @@
 
 package remotely.transport
 
-import java.util.concurrent.ThreadFactory
-import java.util.concurrent.atomic.AtomicInteger
-
-package object netty {
-  def namedThreadFactory(name: String) = new ThreadFactory {
-    val num = new AtomicInteger(1)
-    def newThread(runnable: Runnable) = new Thread(runnable, s"$name - ${num.incrementAndGet}")
-  }
-}
+package object netty


### PR DESCRIPTION
… in the context of the current task by using Task.delay rather than Task.apply since they will always use the default executor which has a limited thread pool and if a read task is used as the basis for a large operation as is done in CircuitBreaker, it could block waiting for a thread to write, which could all be taken by others blocking waiting to read a task, resulting in a thread starvation deadlock (as is currently the case with Circuit Breaker when the number of concurrent tasks invoking it on an endpoint exceeds the number of cores on the target system.  I also added a separate strategy for the mergeN used by the uber to race a pool of handlers - without it, it will use the default thread pool (of n threads where n == number of cores) and netty client transport connection pool creators also use that pool so if enough concurrent clients are using a thread in the raced pool (in which threads they will also attempt to fork another in the same pool for object creation), you get another thread starvation/deadlock.