### PR TITLE
Bugfix/hanging endpoints

### DIFF
--- a/core/src/main/scala/Endpoint.scala
+++ b/core/src/main/scala/Endpoint.scala
@@ -26,7 +26,7 @@ import scalaz.stream.{async,Channel,Exchange,io,Process,nio,Process1, process1, 
 import scodec.bits.{BitVector}
 import scala.concurrent.duration._
 import scalaz._
-import Process.{Await, Emit, Halt, emit, await, halt, eval, await1, iterate}
+import Process.{Await, Emit, Halt, emit, emitAll, await, halt, eval, await1, iterate, receive1}
 import scalaz.stream.merge._
 
 /**
@@ -39,17 +39,18 @@ case class Endpoint(connections: Process[Task,Handler]) {
     case Some(a) => Task.now(a)
   }
 
-
   /**
     * Adds a circuit-breaker to this endpoint that "opens" (fails fast) after
     * `maxErrors` consecutive failures, and attempts a connection again
     * when `timeout` has passed.
     */
   def circuitBroken(timeout: Duration, maxErrors: Int): Endpoint =
-    Endpoint(connections.map(c => (bs: Process[Task,BitVector]) => c(bs).translate(CircuitBreaker(timeout, maxErrors).transform)))
+    Endpoint(connections.map(c => bs => c(bs).translate(CircuitBreaker(timeout, maxErrors).transform)))
 }
 
 object Endpoint {
+
+  private val UberPoolChunkSize = 64
 
   def empty: Endpoint = Endpoint(Process.halt)
   def single(transport: Handler): Endpoint = Endpoint(Process.constant(transport))
@@ -61,12 +62,12 @@ object Endpoint {
     */
   def failoverChain(timeout: Duration, es: Process[Task, Endpoint]): Endpoint = {
     def reduceHandlers(f: (Handler, Handler) => Handler): Process1[Handler, Handler] = {
-      def go(a: Handler): Process1[Handler, Handler] = emit(a) ++ receive1(b => scan(f(a, b))(f))
+      def go(a: Handler): Process1[Handler, Handler] = emit(a) ++ receive1(b => go(f(a, b)))
       receive1(a => receive1(b => go(f(a, b))))
     }
     Endpoint(transpose(es.map(_.connections)).flatMap { cs =>
       cs |> reduceHandlers((c1, c2) => bs => c1(bs) match {
-        case w@Await(a, k) => await(time(a.attempt))((p: (Duration, Throwable \/ Any)) => p match {
+        case Await(a, k) => await(time(a.attempt))((p: (Duration, Throwable \/ Any)) => p match {
           case (d, -\/(e)) => if (timeout - d > 0.milliseconds) c2(bs) else eval(Task.fail(new Exception(s"Failover chain timed out after $timeout")))
           case (d, \/-(x)) => k(\/-(x)).run
         })
@@ -84,7 +85,8 @@ object Endpoint {
            circuitOpenTime: Duration,
            maxErrors: Int,
            es: Process[Task, Endpoint]): Endpoint = {
-    Endpoint(raceHandlerPool(permutations(es).map(ps => failoverChain(maxWait, ps.map(_.circuitBroken(circuitOpenTime, maxErrors))).connections)))
+    val effectivePool = permutations(es |> process1.chunk(UberPoolChunkSize) |> receive1(emitAll)).repeat
+    Endpoint(raceHandlerPool(effectivePool.map(ps => failoverChain(maxWait, ps.map(_.circuitBroken(circuitOpenTime, maxErrors))).connections)))
   }
 
   /**

--- a/core/src/test/scala/EndpointSpec.scala
+++ b/core/src/test/scala/EndpointSpec.scala
@@ -32,7 +32,7 @@ class EndpointSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     val goodEndpoint = (NettyTransport.single(goodAddress) map Endpoint.single).run
     val badEndpoint = (NettyTransport.single(badAddress) map Endpoint.single).run
 
-    def endpoints: Process[Nothing,Endpoint] = Process.emitAll(List(badEndpoint, goodEndpoint))
+    def endpoints: Process[Nothing,Endpoint] = Process.emitAll(List(badEndpoint, goodEndpoint)) ++ endpoints
 
     val server = new CountServer
 

--- a/core/src/test/scala/UberSpec.scala
+++ b/core/src/test/scala/UberSpec.scala
@@ -74,7 +74,7 @@ class UberSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   val endpointUber = Endpoint.uber(1 second, 10 seconds, 10, endpoints)
 
   behavior of "uber"
-  ignore should "work" in { // this seems to hang
+  it should "work" in {
     import Response.Context
     import Remote.implicits._
     import codecs._


### PR DESCRIPTION
For failover and uber (aggregate) endpoints, if the endpoint isn't finite or reasonably small.  Of course, one could argue that the processes probably shouldn't be anything but a reasonably small collection of endpoints but there's no easy way I know of to enforce this so in case they aren't, I think what I have here should work (I was able to remove the ignore in the UberSpec that had been hanging because of this, since it's using an infinite process - i.e., def endpoints: Process[Nothing, Endpoint] = Process.emitAll(List(ep1, ep2)) ++ endpoints - or equiv: Process.emitAll(List(ep1, ep2)).repeat).   Pretty low priority, for sure and I'd be just as okay with stating the constraints for the processes passed to failoverChain or uber.