### PR TITLE
Ensure codecs defined by user are byte aligned without the user havin…

### DIFF
--- a/core/src/main/scala/Codecs.scala
+++ b/core/src/main/scala/Codecs.scala
@@ -22,13 +22,13 @@ import shapeless.{HNil, HList, ::}
 
 import scala.reflect.runtime.universe.TypeTag
 import scodec.{Codec,Decoder,Encoder}
+import scodec.codecs.byteAligned
 
 case class Codecs[A <: HList](codecs: Map[String,Codec[Any]]) {
   def codec[C:TypeTag:Codec]: Codecs[C :: A] = {
     val name = Remote.toTag(implicitly[TypeTag[C]])
-    this.copy(codecs = codecs + (name -> Codec[C].asInstanceOf[Codec[Any]]))
+    this.copy(codecs = codecs + (name -> byteAligned(Codec[C].asInstanceOf[Codec[Any]])))
   }
-
 
   def ++[C <: HList](c: Codecs[C])(implicit prepend : Prepend[A, C]) : Codecs[prepend.Out] = Codecs[prepend.Out](codecs ++ c.codecs)
 


### PR DESCRIPTION
…g to worry about it (for instance, if a user defines an optional member of a larger structure with optional(bool, optionalCodec), since bool is by default 1 bit, the codec using it will result in weird runtime error because the codec itself is not byte aligned - by wrapping in byteAligned combinator within Remotely,  it will be transparently byte aligned)