### PR TITLE
Added an implicit function from Codec[A] to Option[Codec[A]] - I left…

### DIFF
--- a/core/src/main/scala/codecs/codecs.scala
+++ b/core/src/main/scala/codecs/codecs.scala
@@ -86,9 +86,11 @@ package object codecs extends lowerprioritycodecs {
 
   private def empty: Codec[Unit] = C.provide(())
 
-  def optional[A](target: Codec[A]): Codec[Option[A]] =
-    either(empty, target).
-      xmap[Option[A]](_.toOption, _.toRightDisjunction(()))
+  @deprecated("Use the implicit `Option[A]` resolution provided by this package instead.", "1.4.3")
+  def optional[A](target: Codec[A]): Codec[Option[A]] = option(Lazy(target))
+
+  implicit def option[A](implicit LCA: Lazy[Codec[A]]): Codec[Option[A]] =
+    either(empty, LCA.value).xmap[Option[A]](_.toOption, _.toRightDisjunction(()))
 
   implicit def list[A](implicit LCA: Lazy[Codec[A]]): Codec[List[A]] =
     indexedSeq[A].xmap[List[A]](


### PR DESCRIPTION
… the original non-implicit in place for backward compatibility but deprecated it in favor of the implicit since that is the convention with the other stdlib codecs here.