### PR TITLE
Updated revisions of libs: scodec 1.10, scalaz-stream 0.8.1, scalaz 7…

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -17,10 +17,10 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scodec"         %% "scodec-core"   % "1.8.2",
-  "org.scodec"         %% "scodec-scalaz" % "1.1.0",
-  "org.scalaz"         %% "scalaz-core"   % "7.1.3",
-  "org.scalaz.stream"  %% "scalaz-stream" % "0.7.3a",
+  "org.scodec"         %% "scodec-core"   % "1.10.0",
+  "org.scodec"         %% "scodec-scalaz" % "1.3.0",
+  "org.scalaz"         %% "scalaz-core"   % "7.1.8",
+  "org.scalaz.stream"  %% "scalaz-stream" % "0.8.1",
   "org.apache.commons" % "commons-pool2"  % "2.4.2",
   "io.netty"           % "netty-handler"  % "4.1.0.Final",
   "io.netty"           % "netty-codec"    % "4.1.0.Final"

--- a/core/src/main/scala/Endpoint.scala
+++ b/core/src/main/scala/Endpoint.scala
@@ -62,7 +62,7 @@ object Endpoint {
   def failoverChain(timeout: Duration, es: Process[Task, Endpoint]): Endpoint =
     Endpoint(transpose(es.map(_.connections)).flatMap { cs =>
                cs.reduce((c1, c2) => bs => c1(bs) match {
-                           case w@Await(a, k) =>
+                           case w@Await(a, k, _) =>
                              await(time(a.attempt))((p: (Duration, Throwable \/ Any)) => p match {
                                                       case (d, -\/(e)) =>
                                                         if (timeout - d > 0.milliseconds) c2(bs)

--- a/core/src/main/scala/Utils.scala
+++ b/core/src/main/scala/Utils.scala
@@ -31,10 +31,4 @@ package object utils {
     }
   }
   implicit def errToE(err: Err) = new DecodingFailure(err)
-  implicit class AugmentedAttempt[A](a: Attempt[A]) {
-    def toTask(implicit conv: Err => Throwable): Task[A] = a match {
-      case Failure(err) => Task.fail(conv(err))
-      case Successful(a) => Task.now(a)
-    }
-  }
 }

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -26,6 +26,7 @@ package object remotely {
   import scalaz.\/.{left,right}
   import scalaz.Monoid
   import scodec.bits.{BitVector,ByteVector}
+  import scodec.interop.scalaz._
 //  import scodec.Decoder
   import utils._
 
@@ -90,9 +91,6 @@ package object remotely {
       } yield result
     }
   }}
-
-  implicit val BitVectorMonoid = Monoid.instance[BitVector]((a,b) => a ++ b, BitVector.empty)
-  implicit val ByteVectorMonoid = Monoid.instance[ByteVector]((a,b) => a ++ b, ByteVector.empty)
 
   private[remotely] def fullyRead(s: Process[Task,BitVector]): Task[BitVector] = s.runFoldMap(x => x)
 

--- a/core/src/main/scala/transport/netty/ClientConnectionPool.scala
+++ b/core/src/main/scala/transport/netty/ClientConnectionPool.scala
@@ -62,7 +62,8 @@ class NettyConnectionPool(hosts: Process[Task,InetSocketAddress],
                           M: Monitoring,
                           sslContext: Option[SslContext]) extends BasePooledObjectFactory[Channel] {
 
-  val numWorkerThreads = workerThreads getOrElse Runtime.getRuntime.availableProcessors
+  val numWorkerThreads = workerThreads getOrElse Runtime.getRuntime.availableProcessors.max(4)
+
   val workerThreadPool = new NioEventLoopGroup(numWorkerThreads, namedThreadFactory("nettyWorker"))
 
   val validateCapabilities: ((Capabilities,Channel)) => Task[Channel] = {
@@ -97,7 +98,6 @@ class NettyConnectionPool(hosts: Process[Task,InetSocketAddress],
           )
 
         } flatMap(_ => Task.fail(error))
-
       }
   }
 

--- a/core/src/main/scala/transport/netty/Server.scala
+++ b/core/src/main/scala/transport/netty/Server.scala
@@ -16,7 +16,7 @@
 //: ----------------------------------------------------------------------------
 
 package remotely
-package transport.netty 
+package transport.netty
 
 import java.util.concurrent.Executors
 import io.netty.channel._, socket.SocketChannel, nio.NioEventLoopGroup
@@ -65,9 +65,9 @@ private[remotely] class NettyServer(handler: Handler,
   /**
     * once a connection is negotiated, we send our capabilities string
     * to the client, which might look something like:
-    *  
+    *
     * OK: [Remotely 1.0]
-    */ 
+    */
   @ChannelHandler.Sharable
   object ChannelInitialize extends ChannelInboundHandlerAdapter {
     override def channelRegistered(ctx: ChannelHandlerContext): Unit = {
@@ -105,7 +105,7 @@ private[remotely] class NettyServer(handler: Handler,
 object NettyServer {
   /**
     * start a netty server listening to the given address
-    * 
+    *
     * @param addr the address to bind to
     * @param handler the request handler
     * @param strategy the strategy used for processing incoming requests
@@ -128,7 +128,7 @@ object NettyServer {
     SslParameters.toServerContext(sslParameters) map { ssl =>
       logger.negotiating(Some(addr), s"got ssl parameters: $ssl", None)
       val numBossThreads = bossThreads getOrElse 2
-      val numWorkerThreads = workerThreads getOrElse Runtime.getRuntime.availableProcessors
+      val numWorkerThreads = workerThreads getOrElse Runtime.getRuntime.availableProcessors.max(4)
 
       val server = new NettyServer(handler, strategy, numBossThreads, numWorkerThreads, capabilities, logger, ssl.map(_ -> sslParameters.fold(true)(p => p.requireClientAuth)))
       val b = server.bootstrap

--- a/core/src/main/scala/transport/netty/Transport.scala
+++ b/core/src/main/scala/transport/netty/Transport.scala
@@ -177,9 +177,9 @@ object Enframe extends ChannelOutboundHandlerAdapter {
     obj match {
       case Bits(bv) =>
         val byv = bv.toByteVector
-        val _ = ctx.write(Unpooled.wrappedBuffer((codecs.int32.encode(byv.size).require ++ bv).toByteBuffer), cp)
+        val _ = ctx.writeAndFlush(Unpooled.wrappedBuffer((codecs.int32.encode(byv.size.toInt).require ++ bv).toByteBuffer), cp)
       case EOS =>
-        val _ = ctx.write(Unpooled.wrappedBuffer(codecs.int32.encode(0).require.toByteBuffer), cp)
+        val _ = ctx.writeAndFlush(Unpooled.wrappedBuffer(codecs.int32.encode(0).require.toByteBuffer), cp)
       case x => throw new IllegalArgumentException("was expecting Framed, got: " + x)
     }
   }


### PR DESCRIPTION
….1.8, commons-pool-2.4.2, netty 4.1.0, flush client request in pipeline to avoid ~1 sec lags, minimum of 4 *default* endpoint and worker threads to avoid 100 to 200ms lags with single CPU machines awaiting for free connection.

This subsumes PRs 106 - 108 and adds:
1.) update of scodec, scalaz-stream (0.8.x) and scalaz (7.1.x) to latest.
2.) sets a minimum for endpoint and worker threads when they are not set by client but default to num processors, as it has been observed that there were lags even when processing one request at a time when the thread pool were less than 4 due to non-connection use of the thread (overhead, decoding, encoding).  The worker threads can be configured to be higher, obviously, but endpoint pool can't.  If acceptable and it is desired to merge 106 - 108 individually, I can re-base this to just include the deltas. Or if it is desired just to bump the versions and not include the thread pool changes.  @ahjohannessen, FYI ...
These changes constitutes the deltas from 1.4.3 which we are using in our application now.