### PR TITLE
core: revert hlist for codecs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   - 2.10.6
-  - 2.11.7
+  - 2.11.8
 
 jdk:
   - oraclejdk8

--- a/core/src/main/scala/Codecs.scala
+++ b/core/src/main/scala/Codecs.scala
@@ -17,20 +17,18 @@
 
 package remotely
 
-import shapeless.ops.hlist.Prepend
-import shapeless.{HNil, HList, ::}
-
 import scala.reflect.runtime.universe.TypeTag
-import scodec.{Codec,Decoder,Encoder}
+import scodec.Codec
 import scodec.codecs.byteAligned
 
-case class Codecs[A <: HList](codecs: Map[String,Codec[Any]]) {
-  def codec[C:TypeTag:Codec]: Codecs[C :: A] = {
+case class Codecs(codecs: Map[String,Codec[Any]]) {
+
+  def codec[C:TypeTag:Codec]: Codecs = {
     val name = Remote.toTag(implicitly[TypeTag[C]])
     this.copy(codecs = codecs + (name -> byteAligned(Codec[C].asInstanceOf[Codec[Any]])))
   }
 
-  def ++[C <: HList](c: Codecs[C])(implicit prepend : Prepend[A, C]) : Codecs[prepend.Out] = Codecs[prepend.Out](codecs ++ c.codecs)
+  def ++(c: Codecs): Codecs = Codecs(codecs ++ c.codecs)
 
   def keySet = codecs.keySet
 
@@ -43,5 +41,5 @@ case class Codecs[A <: HList](codecs: Map[String,Codec[Any]]) {
 
 object Codecs {
 
-  val empty: Codecs[HNil] = Codecs(Map("List[remotely.Signature]" -> codecs.set(Signature.signatureCodec).asInstanceOf[Codec[Any]]))
+  val empty: Codecs = Codecs(Map("List[remotely.Signature]" -> codecs.set(Signature.signatureCodec).asInstanceOf[Codec[Any]]))
 }

--- a/core/src/main/scala/Environment.scala
+++ b/core/src/main/scala/Environment.scala
@@ -18,15 +18,11 @@
 package remotely
 
 import java.net.InetSocketAddress
-import javax.net.ssl.SSLEngine
-import shapeless._
-
 import scala.reflect.runtime.universe.TypeTag
-import scodec.{Codec,Decoder,Encoder}
-import scodec.bits.{BitVector}
+import scodec.Codec
+import scodec.bits.BitVector
 import scalaz.stream.Process
-import scalaz.concurrent.{Strategy,Task}
-import scala.concurrent.duration.DurationInt
+import scalaz.concurrent.{Strategy, Task}
 
 /**
  * A collection of codecs and values, which can be populated
@@ -45,20 +41,20 @@ import scala.concurrent.duration.DurationInt
  *   stopper() // shutdown the server
  * }}}
  */
-case class Environment[H <: HList](codecs: Codecs[H], values: Values) {
+case class Environment(codecs: Codecs, values: Values) {
 
-  def codec[A](implicit T: TypeTag[A], C: Codec[A]): Environment[A :: H] =
+  def codec[A](implicit T: TypeTag[A], C: Codec[A]): Environment =
     this.copy(codecs = codecs.codec[A])
 
   /**
    * Modify the values inside this `Environment`, using the given function `f`.
    * Example: `Environment.empty.populate { _.declare("x")(Task.now(42)) }`.
    */
-  def populate(f: Values => Values): Environment[H] =
+  def populate(f: Values => Values): Environment =
     this.copy(values = f(values))
 
   /** Alias for `this.populate(_ => v)`. */
-  def values(v: Values): Environment[H] =
+  def values(v: Values): Environment =
     this.populate(_ => v)
 
   private def serverHandler(monitoring: Monitoring): Handler = { bytes =>

--- a/core/src/main/scala/GenServer.scala
+++ b/core/src/main/scala/GenServer.scala
@@ -24,7 +24,7 @@ import scala.annotation.StaticAnnotation
  * Macro annotation that generates a server interface. Usage:
  * `@GenServer(remotely.Protocol.empty) abstract class MyServer`
  */
-class GenServer(p: Protocol[_]) extends StaticAnnotation {
+class GenServer(p: Protocol) extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro GenServer.impl
 }
 
@@ -42,9 +42,9 @@ object GenServer extends MacrosCompatibility {
 
     // Pull out the Protocol expression from the macro annotation
     // and evaluate it at compile-time.
-    val p:Protocol[_] = c.prefix.tree match {
+    val p:Protocol = c.prefix.tree match {
       case q"new $name($protocol)" =>
-        c.eval(c.Expr[Protocol[_]](resetLocalAttrs(c)(q"{import remotely.codecs._; import remotely.Field; import remotely.Type; $protocol}")))
+        c.eval(c.Expr[Protocol](resetLocalAttrs(c)(q"{import remotely.codecs._; import remotely.Field; import remotely.Type; $protocol}")))
       case _ => c.abort(c.enclosingPosition, "GenServer must be used as an annotation.")
     }
 
@@ -80,7 +80,7 @@ object GenServer extends MacrosCompatibility {
               import remotely.{Codecs,Environment,Response,Values}
               import remotely.codecs._
 
-              def environment = Environment(
+              def environment: Environment = Environment(
                 $codecs,
                 populateDeclarations(Values.empty)
               )

--- a/core/src/main/scala/Protocol.scala
+++ b/core/src/main/scala/Protocol.scala
@@ -17,33 +17,30 @@
 
 package remotely
 
-import shapeless._
-import shapeless.ops.hlist.Selector
-
 import scala.reflect.runtime.universe.TypeTag
 import scodec.Codec
 
-case class Protocol[H <: HList](codecs: Codecs[H], signatures: Signatures) {
+case class Protocol(codecs: Codecs, signatures: Signatures) {
 
-  def codec[A:TypeTag:Codec]: Protocol[A :: H] =
+  def codec[A:TypeTag:Codec]: Protocol =
     this.copy(codecs = codecs.codec[A])
 
-  def specify0[O](name: String, out: Type[O])(implicit evidenceA : Selector[H, O]): Protocol[H] =
+  def specify0[O](name: String, out: Type[O]): Protocol =
     this.copy(signatures = signatures.specify0(name, out.name))
 
-  def specify1[A,O](name: String, in: Field[A], out: Type[O])(implicit evidenceA : Selector[H, A], evidenceB : Selector[H, O]): Protocol[H] =
+  def specify1[A,O](name: String, in: Field[A], out: Type[O]): Protocol =
     this.copy(signatures = signatures.specify1(name, in, out.name))
 
-  def specify2[A,B,O](name: String, in1: Field[A], in2: Field[B], out: Type[O])(implicit evidenceA : Selector[H, A], evidenceB : Selector[H, B], evidenceC : Selector[H, O]): Protocol[H] =
+  def specify2[A,B,O](name: String, in1: Field[A], in2: Field[B], out: Type[O]): Protocol =
     this.copy(signatures = signatures.specify2(name, in1, in2, out.name))
 
-  def specify3[A,B,C,O](name: String, in1: Field[A], in2: Field[B], in3: Field[C], out: Type[O])(implicit evidenceA : Selector[H, A], evidenceB : Selector[H, B], evidenceC : Selector[H, C], evidenceD: Selector[H, O]): Protocol[H] =
+  def specify3[A,B,C,O](name: String, in1: Field[A], in2: Field[B], in3: Field[C], out: Type[O]): Protocol =
     this.copy(signatures = signatures.specify3(name, in1, in2, in3, out.name))
 
-  def specify4[A,B,C,D,O](name: String, in1: Field[A], in2: Field[B], in3: Field[C], in4: Field[D], out: Type[O])(implicit evidenceA : Selector[H, A], evidenceB : Selector[H, B], evidenceC : Selector[H, C], evidenceD: Selector[H, D], evidenceE: Selector[H, O]): Protocol[H] =
+  def specify4[A,B,C,D,O](name: String, in1: Field[A], in2: Field[B], in3: Field[C], in4: Field[D], out: Type[O]): Protocol =
     this.copy(signatures = signatures.specify4(name, in1, in2, in3, in4, out.name))
 
-  def specify5[A,B,C,D,E,O](name: String, in1: Field[A], in2: Field[B], in3: Field[C], in4: Field[D], in5: Field[E], out: Type[O])(implicit evidenceA : Selector[H, A], evidenceB : Selector[H, B], evidenceC : Selector[H, C], evidenceD: Selector[H, D], evidenceE: Selector[H, E], evidenceF: Selector[H, O]): Protocol[H] =
+  def specify5[A,B,C,D,E,O](name: String, in1: Field[A], in2: Field[B], in3: Field[C], in4: Field[D], in5: Field[E], out: Type[O]): Protocol =
     this.copy(signatures = signatures.specify5(name, in1, in2, in3, in4, in5, out.name))
 
   def pretty: String =
@@ -57,4 +54,66 @@ case class Protocol[H <: HList](codecs: Codecs[H], signatures: Signatures) {
 object Protocol {
 
   val empty = Protocol(Codecs.empty, Signatures.empty)
+
+  /// Convenience Syntax
+
+  implicit class ProtocolOps(inner: Protocol) {
+
+    import Field._
+
+    def ++(other: Protocol): Protocol = Protocol(
+      codecs     = inner.codecs ++ other.codecs,
+      signatures = Signatures(inner.signatures.signatures ++ other.signatures.signatures)
+    )
+
+    def define0[O: TypeTag](name: String): Protocol =
+      inner.specify0(name, Type[O])
+
+    def define1[A: TypeTag, O: TypeTag](name: String): Protocol = {
+
+      val f1 = strict[A]("in1")
+
+      inner.specify1(name, f1, Type[O])
+    }
+
+    def define2[A: TypeTag, B: TypeTag, O: TypeTag](name: String): Protocol = {
+
+      val f1 = strict[A]("in1")
+      val f2 = strict[B]("in2")
+
+      inner.specify2(name, f1, f2, Type[O])
+    }
+
+    def define3[A: TypeTag, B: TypeTag, C: TypeTag, O: TypeTag](name: String): Protocol = {
+
+      val f1 = strict[A]("in1")
+      val f2 = strict[B]("in2")
+      val f3 = strict[C]("in3")
+
+      inner.specify3(name, f1, f2, f3, Type[O])
+    }
+
+    def define4[A: TypeTag, B: TypeTag, C: TypeTag, D: TypeTag, O: TypeTag](name: String): Protocol = {
+
+      val f1 = strict[A]("in1")
+      val f2 = strict[B]("in2")
+      val f3 = strict[C]("in3")
+      val f4 = strict[D]("in4")
+
+      inner.specify4(name, f1, f2, f3, f4, Type[O])
+    }
+
+    def define5[A: TypeTag, B: TypeTag, C: TypeTag, D: TypeTag, E: TypeTag, O: TypeTag](name: String): Protocol = {
+
+      val f1 = strict[A]("in1")
+      val f2 = strict[B]("in2")
+      val f3 = strict[C]("in3")
+      val f4 = strict[D]("in4")
+      val f5 = strict[E]("in5")
+
+      inner.specify5(name, f1, f2, f3, f4, f5, Type[O])
+    }
+
+  }
+
 }

--- a/core/src/main/scala/Server.scala
+++ b/core/src/main/scala/Server.scala
@@ -39,7 +39,7 @@ object Server {
    * use the `monitoring` argument if you wish to observe
    * these failures.
    */
-  def handle(env: Environment[_])(request: BitVector)(monitoring: Monitoring): Task[BitVector] = {
+  def handle(env: Environment)(request: BitVector)(monitoring: Monitoring): Task[BitVector] = {
 
     Task.delay(System.nanoTime).flatMap { startNanos => Task.suspend {
       // decode the request from the environment

--- a/core/src/main/scala/codecs/codecs.scala
+++ b/core/src/main/scala/codecs/codecs.scala
@@ -154,7 +154,7 @@ package object codecs extends lowerprioritycodecs {
     def sizeBound = SizeBound.unknown
   }
 
-  def localRemoteDecoder(env: Codecs[_]): Decoder[Local[Any]] =
+  def localRemoteDecoder(env: Codecs): Decoder[Local[Any]] =
     utf8.flatMap( formatType =>
       env.codecs.get(formatType).map{ codec => codec.map { a => Local(a,None,formatType) } }
         .getOrElse(fail(Err(s"[decoding] unknown format type: $formatType")))
@@ -167,7 +167,7 @@ package object codecs extends lowerprioritycodecs {
    * to a decoder that is not found in `env`, decoding fails
    * with an error.
    */
-  def remoteDecoder(env: Codecs[_]): Decoder[Remote[Any]] = {
+  def remoteDecoder(env: Codecs): Decoder[Remote[Any]] = {
     def go = remoteDecoder(env)
     C.uint8.flatMap {
       case 0 => localRemoteDecoder(env)
@@ -206,7 +206,7 @@ package object codecs extends lowerprioritycodecs {
     sortedSet[String].encode(formats(a))  <+>
     remoteEncode(a)
 
-  def requestDecoder(env: Environment[_]): Decoder[(Encoder[Any],Response.Context,Remote[Any])] =
+  def requestDecoder(env: Environment): Decoder[(Encoder[Any],Response.Context,Remote[Any])] =
     for {
       responseTag <- utf8
       ctx <- Decoder[Response.Context]

--- a/core/src/test/scala/CountServer.scala
+++ b/core/src/test/scala/CountServer.scala
@@ -26,7 +26,7 @@ trait CountServerBase {
   def ping: Int => Response[Int]
   def describe: Response[List[Signature]]
 
-  def environment = Environment(
+  def environment: Environment = Environment(
     Codecs.empty.codec[Int],
     populateDeclarations(Values.empty)
   )

--- a/core/src/test/scala/ProtocolSpec.scala
+++ b/core/src/test/scala/ProtocolSpec.scala
@@ -46,7 +46,7 @@ trait TestServerBase {
 
   import Codecs._
 
-  def environment = Environment(
+  def environment: Environment = Environment(
     Codecs.empty
       .codec[Int]
       .codec[List[Int]]

--- a/project.sbt
+++ b/project.sbt
@@ -3,7 +3,7 @@ organization in Global := "oncue.remotely"
 
 scalaVersion in Global := "2.10.6"
 
-crossScalaVersions in Global := Seq("2.10.6", "2.11.7")
+crossScalaVersions in Global := Seq("2.10.6", "2.11.8")
 
 resolvers += Resolver.sonatypeRepo("releases")
 


### PR DESCRIPTION
 - revert adding hlists to `Codecs` and adjust
   dependant code / specs accordingly.

 - add convenience syntax for `Protocol` such
   that it is simpler to define (specify)
   signatures for protocols.

 - bump scala to 2.11.8