### PR TITLE
deps: downgrade scodec

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -17,8 +17,8 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scodec"         %% "scodec-core"   % "1.10.0",
-  "org.scodec"         %% "scodec-scalaz" % "1.3.0",
+  "org.scodec"         %% "scodec-core"   % "1.8.3",
+  "org.scodec"         %% "scodec-scalaz" % "1.1.0",
   "org.scalaz"         %% "scalaz-core"   % "7.1.8",
   "org.scalaz.stream"  %% "scalaz-stream" % "0.8.1",
   "org.apache.commons" % "commons-pool2"  % "2.4.2",

--- a/core/src/main/scala/Utils.scala
+++ b/core/src/main/scala/Utils.scala
@@ -19,16 +19,25 @@ package remotely
 import remotely.codecs.DecodingFailure
 import scodec.Attempt.{Successful, Failure}
 import scodec.{Attempt, Err}
-
 import scalaz.{\/-, -\/, \/}
 import scalaz.concurrent.Task
 
 package object utils {
+
   implicit class AugmentedEither[E,A](a: E \/ A) {
     def toTask(implicit conv: E => Throwable): Task[A] = a match {
       case -\/(e) => Task.fail(conv(e))
-      case \/-(a) => Task.now(a)
+      case \/-(s) => Task.now(s)
     }
   }
-  implicit def errToE(err: Err) = new DecodingFailure(err)
+
+  implicit def errToE(err: Err): DecodingFailure = new DecodingFailure(err)
+
+  implicit class AugmentedAttempt[A](a: Attempt[A]) {
+    def toTask(implicit conv: Err => Throwable): Task[A] = a match {
+      case Failure(err)  => Task.fail(conv(err))
+      case Successful(s) => Task.now(s)
+    }
+  }
+
 }


### PR DESCRIPTION
 - downgrade scodec-core and scodec-scalaz because
   present versions are incompatible with our dependency
   on scalaz-stream with respect to scodec-bits.

 - add `AugmentedAttempt` implicit helper class back that
   has `toTask` method. This can be removed when we can move
   scodec forward.

 - NOTE: we can upgrade as soon scalaz-stream moves forward
         with respect to scodec.