### PR TITLE
deps: upgrade scalaz-stream / netty

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -20,10 +20,10 @@ libraryDependencies ++= Seq(
   "org.scodec"         %% "scodec-core"   % "1.10.0",
   "org.scodec"         %% "scodec-scalaz" % "1.3.0",
   "org.scalaz"         %% "scalaz-core"   % "7.1.8",
-  "org.scalaz.stream"  %% "scalaz-stream" % "0.8.1",
+  "org.scalaz.stream"  %% "scalaz-stream" % "0.8.2",
   "org.apache.commons" % "commons-pool2"  % "2.4.2",
-  "io.netty"           % "netty-handler"  % "4.1.0.Final",
-  "io.netty"           % "netty-codec"    % "4.1.0.Final"
+  "io.netty"           % "netty-handler"  % "4.1.1.Final",
+  "io.netty"           % "netty-codec"    % "4.1.1.Final"
 )
 
 common.macrosSettings


### PR DESCRIPTION
 - upgrade scalaz-stream to 0.8.2 in order to
   align scodec dependencies.

 - upgrade netty to 4.1.1 due to recommended
   security fix.